### PR TITLE
[chore] Fix Linux update guide

### DIFF
--- a/lessons/gitPrep/text.md
+++ b/lessons/gitPrep/text.md
@@ -353,8 +353,8 @@ brew upgrade gitmastery
   <tab header="Debian/Ubuntu">
 
 ```bash
+sudo apt-get update
 sudo apt-get install --only-upgrade gitmastery
-
 ```
 
   </tab>
@@ -362,7 +362,6 @@ sudo apt-get install --only-upgrade gitmastery
 
 ```bash
 sudo pacman -S gitmastery-bin
-
 ```
   </tab>
 </tabs> <!-- linux versions -->


### PR DESCRIPTION
Students on Debian/Ubuntu are unable to update the app by just running `sudo apt-get install --only-upgrade gitmastery`. They must also run `sudo apt-get update` to refresh their local database of available packages. Thus, it should be added to the instructions.