### PR TITLE
Add inline attribute to course toggle label

### DIFF
--- a/_markbind/layouts/navbar.md
+++ b/_markbind/layouts/navbar.md
@@ -1,5 +1,5 @@
 <navbar placement="top" type="dark">
-  <a slot="brand" href="{{ baseUrl }}/index.html" title="Git-Mastery Home" class="navbar-brand"><md>****Git-Mastery**** <cv-toggle placeholder-id="course"><span class="badge rounded-pill bg-warning text-dark badge-xs">[[course]] edition</span></cv-toggle></md></a>
+  <a slot="brand" href="{{ baseUrl }}/index.html" title="Git-Mastery Home" class="navbar-brand"><md>****Git-Mastery**** &nbsp; <cv-toggle inline placeholder-id="course"><span class="badge rounded-pill bg-warning text-dark badge-xs">[[course]] edition</span></cv-toggle></md></a>
   <li><a href="{{baseUrl}}/index.html" class="nav-link"><md>**Home**</md></a></li>
   <li><a href="{{baseUrl}}/lessons/index.html" class="nav-link"><md>**Lessons**</md></a></li>
   <li><a href="{{baseUrl}}/exercises-directory/index.html" class="nav-link"><md>**Exercises**</md></a></li>


### PR DESCRIPTION
Add inline attribute to course toggle label to make it inline

<img width="1526" height="459" alt="image" src="https://github.com/user-attachments/assets/c3a43b38-bd48-4719-83e3-683ef25f86a7" />

Additionally, add space for styling between "Git-Mastery" title and course label ("&nbsp;") for styling